### PR TITLE
Fix reload on detail page

### DIFF
--- a/src/store/Context.tsx
+++ b/src/store/Context.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 export const AppProvider = ({ children }: Props) => {
   const [state, dispatch] = useReducer(AppReducer, initialState)
-  const url = 'api/state'
+  const url = '/api/state'
 
   useEffect(() => {
     const abortController = new AbortController()


### PR DESCRIPTION
AppProvider missed a leading "/" for the API path